### PR TITLE
Fix in code of Expression

### DIFF
--- a/Chapters/Expressions/Expressions.pillar
+++ b/Chapters/Expressions/Expressions.pillar
@@ -446,8 +446,8 @@ Of course, since we are addicted to tests, we add a new test.
 [[[
 EEAdditionTest >> testEvaluateWithClassCreationMessage
 	| ep1 ep2 |
-	ep1 := EConstant constant5.
-	ep2 := EConstant constant3.
+	ep1 := EConstant value: 5.
+	ep2 := EConstant value: 3.
 	self assert: (EAddition left: ep1 right: ep2) evaluate equals: 8
 ]]]
 

--- a/Chapters/Expressions/Expressions.pillar
+++ b/Chapters/Expressions/Expressions.pillar
@@ -446,8 +446,8 @@ Of course, since we are addicted to tests, we add a new test.
 [[[
 EEAdditionTest >> testEvaluateWithClassCreationMessage
 	| ep1 ep2 |
-	ep1 := EConstant value: 5.
-	ep2 := EConstant value: 3.
+	ep1 := EConstant new value: 5.
+	ep2 := EConstant new value: 3.
 	self assert: (EAddition left: ep1 right: ep2) evaluate equals: 8
 ]]]
 


### PR DESCRIPTION
the messages constant5 and constant3 are defined in the next page and are therefore used too early.
I left the
˜˜˜EConstant new value:5˜˜˜ 
even though we define just before 
˜˜˜EConstant value:5˜˜˜
For coherence, but maybe it should be changed, i don't know.